### PR TITLE
doc: add libwnck3 archlinux depend

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Arch
 
 ```
 sudo pacman -Sy && \
-    sudo pacman -S git python cairo pkgconf gobject-introspection gtk4 python-pipx && \
+    sudo pacman -S git python cairo pkgconf gobject-introspection gtk4 libwnck3 python-pipx && \
     pipx ensurepath && \
     pipx install git+https://github.com/AlfredoSequeida/hints.git
 ```


### PR DESCRIPTION
Cool project!  I couldn't get `hints` to run until I installed `libwnck3` on archlinux. (Still having some issues running on i3, so maybe I've done something else wrong or there are more depends yet to uncover)

```
...
  File "/home/foranw/.local/share/pipx/venvs/hints/lib/python3.13/site-packages/hints/window_manager.py", line 5, in <module>
    require_version("Wnck", "3.0")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/foranw/.local/share/pipx/venvs/hints/lib/python3.13/site-packages/gi/__init__.py", line 125, in require_version
    raise ValueError('Namespace %s not available for version %s' %
                     (namespace, version))
ValueError: Namespace Wnck not available for version 3.0
```