### PR TITLE
Print executed action to stdout on debug

### DIFF
--- a/hints/hints.py
+++ b/hints/hints.py
@@ -206,6 +206,8 @@ def hint_mode(config: HintsConfig, window_system: WindowSystem):
                     case "sway":
                         mouse_y_offset = window_system.bar_height
 
+                logger.debug("performing '%s'", mouse_action)
+
                 match mouse_action["action"]:
                     case "click":
                         click(


### PR DESCRIPTION
this fixes #32 

You suggested `mouse.py`, however this place seems to be better as it directly prints action type (hover, click etc.), where `mouse.py` prints already processed mouse button commands.