### PR TITLE
Fix: Prevent infinite loop in InterceptorWindow keyboard grab

### DIFF
--- a/hints/huds/interceptor.py
+++ b/hints/huds/interceptor.py
@@ -127,9 +127,5 @@ class InterceptorWindow(Gtk.Window):
 
         :param window: Window object.
         """
-        while (
-            not self.is_wayland
-            and Gdk.keyboard_grab(window.get_window(), False, Gdk.CURRENT_TIME)
-            != Gdk.GrabStatus.SUCCESS
-        ):
-            pass
+        if not self.is_wayland:
+            Gdk.keyboard_grab(window.get_window(), False, Gdk.CURRENT_TIME)


### PR DESCRIPTION
This PR fixes a critical bug in the `InterceptorWindow` (used for scroll and drag modes) that caused an infinite loop when keyboard grab acquisition failed. This resulted in application freezes, 100% CPU core usage, and required forceful termination via `killall` or system restart.

**Observed Behavior:**
On Linux Mint X11 systems, the scrollbar functionality would initially work correctly but then trigger a complete system freeze (unresponsive screen and keyboard input) for extended periods, necessitating a full system restart to regain control.

**Solution:**
The fix replaces the `while` loop in the `on_grab` method with a single, safer keyboard grab attempt, preventing application freezes when the grab cannot be immediately acquired.