### PR TITLE
Add security scanning CI (CodeQL, pip-audit, Dependabot) and pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+name: Security Scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Mondays
+  workflow_dispatch:
+
+jobs:
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v3
+
+  pip-audit:
+    name: Dependency Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y libgirepository1.0-dev libcairo2-dev pkg-config \
+            python3-dev libdbus-1-dev gir1.2-gtk-4.0
+      - name: Install project
+        run: pip install -e .
+      - uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          local: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,10 +19,10 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: python
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
 
   pip-audit:
     name: Dependency Vulnerability Scan

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,19 @@ repos:
         name: bandit (security linter)
         args: ["-r", "-ll"]
         # -r recursive, -ll report medium+ severity
-        # pip-audit is intentionally omitted: installing this project
-        # requires system libs (libgirepository, Cairo) unavailable in
-        # pre-commit's isolated environment. It runs in CI instead.
+
+  - repo: local
+    hooks:
+      - id: pip-audit
+        name: pip-audit (dependency scan)
+        language: system
+        entry: pip-audit
+        args: ["-r", "requirements.txt", "--no-deps"]
+        pass_filenames: false
+        # language: system uses the system Python, giving pip access to system
+        # libs (libgirepository, Cairo) needed to build PyGObject metadata.
+        # --no-deps checks only direct dependencies from requirements.txt
+        # (which mirrors install_requires in setup.py), not transitive deps.
+        # Transitive dependency CVEs are caught by pip-audit in CI where the
+        # full project is installed in a clean runner with system libs present.
+        # Requires pip-audit in the active environment: pip install pip-audit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        name: bandit (security linter)
+        args: ["-r", "-ll"]
+        # -r recursive, -ll report medium+ severity
+        # pip-audit is intentionally omitted: installing this project
+        # requires system libs (libgirepository, Cairo) unavailable in
+        # pre-commit's isolated environment. It runs in CI instead.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,42 @@ pip install -e .
 
 At this point, hints should be installed locally in the virtual environment, you can run `hints` in your shell to launch it. Any edits you make to the source code will automatically update the installation. For future development work, you can simply re-enable the virtual environment (step 2).
 
+## Pre-commit validation
+
+hints uses [pre-commit](https://pre-commit.com) to run security checks locally before each commit:
+
+- **bandit** — static analysis (SAST) for Python security issues, runs on staged files.
+- **pip-audit** — dependency vulnerability scan against the [OSV database](https://osv.dev), runs against `requirements.txt`.
+
+### Setup
+
+4. Install pre-commit:
+
+```
+pip install pre-commit
+```
+
+5. Install pip-audit:
+
+```
+pip install pip-audit
+```
+
+6. Install the git hooks:
+
+```
+pre-commit install
+```
+
+The hooks will now run automatically on every `git commit`. You can also run them manually at any time:
+
+```
+pre-commit run --all-files
+```
+
+> [!NOTE]
+> `PyGObject` is excluded from `requirements.txt` used by pip-audit because it requires `gobject-introspection` system headers to build package metadata, which are not universally available. It is covered by pip-audit in CI.
+
 ## Development tips
 
 - If you are making updates that impact hints, you will most likely need to test displaying hints and might find yourself executing hints but not being quick enough to switch to a window to see hints. To get around this, you can execute `hints` with a short pause in your shell: `sleep 0.5; hints`. This way you can have time to switch to a window and see any errors / logs in your shell.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+# Runtime dependencies — mirrors install_requires in setup.py.
+# Kept in sync manually; used by pip-audit for local dependency scanning.
+#
+# PyGObject is intentionally excluded: it requires gobject-introspection system
+# headers to build metadata, which are not universally available. It is covered
+# by pip-audit in CI where system libs are installed explicitly.
+pillow
+pyscreenshot
+opencv-python
+evdev
+dbus-python
+rich


### PR DESCRIPTION
## Summary

Implements the security scanning proposal from #91.

Adds free, automated security scanning at two levels:

### CI (GitHub Actions)
- **CodeQL** — SAST for Python; finds logic bugs, injection flaws, unsafe API usage. Results appear in Security > Code scanning.
- **pip-audit** — fully installs the project (including PyGObject) in a clean Ubuntu runner with system libs, then scans all dependencies including transitive ones against the OSV database for known CVEs.
- **Dependabot** — opens PRs automatically when pip dependencies or GitHub Actions versions have updates.

### Local (pre-commit)
- **bandit** — SAST on staged Python files before each commit; immediate local feedback without waiting for CI.
- **pip-audit** — scans direct dependencies from `requirements.txt` against the OSV database before each commit.
  - PyGObject is excluded from `requirements.txt`: it requires `gobject-introspection` system headers to build metadata, which are not universally available locally. It is fully covered by pip-audit in CI.
  - Transitive dependency CVEs are covered by pip-audit in CI.

## Files added / modified

| File | Purpose |
|------|---------|
| `.github/workflows/security.yml` | CodeQL + pip-audit CI jobs |
| `.github/dependabot.yml` | Weekly dependency update checks |
| `.pre-commit-config.yaml` | bandit SAST + pip-audit hooks (local) |
| `requirements.txt` | Direct dependencies for local pip-audit (mirrors `setup.py install_requires`) |
| `README.md` | Expanded Contributing/Development section with pre-commit setup instructions |

## Trigger conditions (CI)

- Push or PR to `main`
- Weekly schedule (Mondays 06:00 UTC)
- Manual via `workflow_dispatch`

## Pre-existing findings

bandit surfaced the following in the existing codebase (not introduced by this PR):
- `shell=True` in subprocess calls (`hints.py`, `setup.py`, `plasmashell.py`, others) — CWE-78
- `pickle.loads` from a Unix domain socket (`mouse.py`, `mouse_service.py`) — CWE-502
- Hardcoded `/tmp` socket path (`constants.py`) — CWE-377

These are reported for the maintainer's awareness. The pre-commit hook runs only on staged files so it won't block existing workflows.

All tooling is free for public repositories — no external accounts or tokens required. All CI jobs have been validated on the fork before this PR.