### PR TITLE
Fix a typo and scrolling on multi-layout setups.

### DIFF
--- a/hints/huds/interceptor.py
+++ b/hints/huds/interceptor.py
@@ -105,16 +105,7 @@ class InterceptorWindow(Gtk.Window):
     def on_key_press(self, _, event):
         """Handle key presses :param event: Event object."""
 
-        keymap = Gdk.Keymap.get_for_display(Gdk.Display.get_default())
-
-        # if keyval is bound, keyval, effective_group, level, consumed_modifiers
-        _, keyval, _, _, _ = keymap.translate_keyboard_state(
-            event.hardware_keycode,
-            Gdk.ModifierType(event.state & ~Gdk.ModifierType.LOCK_MASK),
-            1,
-        )
-
-        keyval_lower = Gdk.keyval_to_lower(keyval)
+        keyval_lower = Gdk.keyval_to_lower(event.keyval)
 
         if keyval_lower == self.config["exit_key"]:
             self._mouse.click(

--- a/hints/service.py
+++ b/hints/service.py
@@ -395,7 +395,7 @@ class HintsService:
                     {
                         "click": self.mouse.click,
                         "move": self.mouse.move,
-                        "scoll": self.mouse.scroll,
+                        "scroll": self.mouse.scroll,
                         "do_mouse_action": self.mouse.do_mouse_action,
                         "show_hints": self.show_hints,
                     }[method](*args, **kwargs)


### PR DESCRIPTION
This PR was co-authored by AI.
Scroll was not working for me, after some searching I have found that this could be easy fixed by copying a part of overlay.py.
Also, there was a typo inside service.py.
These fixes were tested on a multi keyboard layout i3wm X11 CachyOS setup.