### PR TITLE
Add '-c' argument for default config generation

### DIFF
--- a/hints/cli.py
+++ b/hints/cli.py
@@ -18,6 +18,8 @@ from socket import AF_UNIX, SOCK_STREAM, socket
 
 from hints import __version__
 from hints.ipc_constants import SOCKET_MESSAGE_SIZE, UNIX_DOMAIN_SOCKET_FILE
+from hints.utils import save_default_config
+from hints.constants import CONFIG_PATH
 
 
 def trigger_daemon(mode: str, verbose: int) -> dict:
@@ -88,10 +90,21 @@ def main():
     parser.add_argument(
         "-s", "--setup", action="store_true", default=False, help="Guided hints setup."
     )
+    parser.add_argument(
+        "-c", "--config", action="store_true", default=False, help="Generate default config."
+    )
     args = parser.parse_args()
 
     if args.version:
         print(__version__)
+        return
+
+    if args.config:
+        saved = save_default_config()
+        if saved:
+            print(f"Default config file was created at {CONFIG_PATH}")
+        else:
+            print(f"Failed to create default config file. Check that {CONFIG_PATH} does not exist.")
         return
 
     # Fast path: non-verbose hint mode triggers the warm daemon. Any verbose,

--- a/hints/utils.py
+++ b/hints/utils.py
@@ -1,5 +1,6 @@
-from json import load
+from json import load, dump
 from typing import Any
+from pathlib import Path
 
 from hints.constants import CONFIG_PATH, DEFAULT_CONFIG
 
@@ -37,3 +38,21 @@ def load_config() -> HintsConfig:
         pass
 
     return merge_configs(config, DEFAULT_CONFIG)
+
+
+def save_default_config() -> bool:
+    """Create the default config file if it does not exist.
+
+    :return: if config file was created succesfully.
+    """
+    file_path = Path(CONFIG_PATH)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with open(file_path, "x", encoding="utf-8") as _f:
+            dump(DEFAULT_CONFIG, _f, indent=4)
+        return True
+    except FileExistsError:
+        return False
+    except (IOError, OSError):
+        return False


### PR DESCRIPTION
There is a detailed description of editing the default config in the [configuration guide](https://github.com/AlfredoSequeida/hints/wiki/Configuration-guide), but the default config itself is presented only in the form of a link to [constants file](https://github.com/AlfredoSequeida/hints/blob/main/hints/constants.py). However, value of the `DEFAULT_CONFIG` variable from that file can not be copied into `~/.config/hints/config.json` as is, because it contains Python comments, references Python constants, etc. This argument will generate the default config at `CONFIG_PATH`, if file is not already present (to avoid accidental overwrite of customized config).